### PR TITLE
Added tests and continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+
+python:
+  - "2.7"
+  - "3.6"
+
+env:
+  - LEKTOR=pypi
+  - LEKTOR=master
+
+before_install:
+  - if [[ $LEKTOR == master ]]; then travis_retry pip install git+https://github.com/lektor/lektor.git#egg=Lektor; fi
+
+install:
+  - travis_retry pip install --upgrade pytest
+  - travis_retry pip install --upgrade codecov
+  - travis_retry pip install --editable .[test]
+
+script: pytest --cov=lektor_markdown_header_anchors
+
+after_success:
+  - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+matrix:
+  fast_finish: true
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+    - PYTHON: "C:\\Python36"
+
+install:
+  - "%PYTHON%\\python.exe -m pip install --upgrade pytest"
+  - "%PYTHON%\\python.exe -m pip install --upgrade codecov"
+  - "%PYTHON%\\python.exe -m pip install --editable .[test]"
+
+test_script:
+  - "%PYTHON%\\python.exe --version"
+  - "%PYTHON%\\python.exe -m pip list"
+  - "%PYTHON%\\Scripts\\pytest.exe . --tb=short -v --cov=lektor_markdown_header_anchors"
+
+# Not a .NET project
+build: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[aliases]
+test=pytest

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,13 @@
 from setuptools import setup
 
+tests_require = [
+    'lektor',
+    'mistune',
+    'pytest',
+    'pytest-cov',
+    'pytest-mock'
+]
+
 setup(
     name='lektor-markdown-header-anchors',
     description='Adds support for anchors and table of contents to Markdown.',
@@ -9,6 +17,9 @@ setup(
     version='0.2',
     license='BSD',
     py_modules=['lektor_markdown_header_anchors'],
+    setup_requires=['pytest-runner'],
+    tests_require=tests_require,
+    extras_require={'test': tests_require},    
     entry_points={
         'lektor.plugins': [
             'markdown-header-anchors = lektor_markdown_header_anchors:MarkdownHeaderAnchorsPlugin',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import os
+import py
+import pytest
+import time
+
+from lektor.project import Project
+from lektor.environment import Environment
+
+from lektor_markdown_header_anchors import MarkdownHeaderAnchorsPlugin
+
+
+def pytest_generate_tests(metafunc):
+    if 'project' in metafunc.fixturenames:
+        cwd = os.path.dirname(__file__) 
+        metafunc.parametrize(
+            "project_path", [
+                os.path.join(cwd, 'demo-project'),
+                os.path.join(cwd, 'demo-project-random'),
+            ], indirect=True)
+
+
+@pytest.fixture(scope='function')
+def project_path(request):
+    return request.param
+
+
+@pytest.fixture(scope='function')
+def project(project_path):
+    return Project.from_path(project_path, 'demo-project')
+
+
+@pytest.fixture(scope='function')
+def env(project):
+    return Environment(project)
+
+
+@pytest.fixture
+def plugin(env):
+    return MarkdownHeaderAnchorsPlugin(env, "markdown-header-anchors")

--- a/tests/demo-project-random/configs/markdown-header-anchors.ini
+++ b/tests/demo-project-random/configs/markdown-header-anchors.ini
@@ -1,0 +1,1 @@
+anchor-type = random

--- a/tests/demo-project-random/demo-project.lektorproject
+++ b/tests/demo-project-random/demo-project.lektorproject
@@ -1,0 +1,2 @@
+[project]
+name = Demo Project

--- a/tests/demo-project/demo-project.lektorproject
+++ b/tests/demo-project/demo-project.lektorproject
@@ -1,0 +1,2 @@
+[project]
+name = Demo Project

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,60 @@
+from collections import Counter
+
+import py
+import mistune
+
+from lektor.markdown import MarkdownConfig
+
+
+def make_toc(plugin, text):
+    
+    cfg = MarkdownConfig()
+    plugin.on_markdown_config(cfg)
+
+    renderer = cfg.make_renderer()
+    md = mistune.Markdown(renderer, **cfg.options)
+
+    meta = {}
+    md.renderer.meta = meta
+
+    plugin.on_markdown_meta_init(meta)
+    md(text)
+    plugin.on_markdown_meta_postprocess(meta)
+
+    return meta['toc']
+
+
+def iter_entries(*entries):
+    for entry in entries:
+        yield entry
+        for child in entry.children:
+            for e in iter_entries(child):
+                yield e
+
+
+def test_unique_anchors(plugin):
+    text = """
+# H1
+# H1
+    """
+    cnt = Counter(e.anchor for e in iter_entries(*make_toc(plugin, text)))
+    assert cnt.most_common(1)[0][1] == 1
+
+
+def test_inverse_headers(plugin):
+    text = """
+#### H4
+## H2
+    """
+    toc = make_toc(plugin, text)
+    assert len( make_toc(plugin, text) ) == 2
+
+
+def test_two_level_jump(plugin):
+    text = """
+## H2
+#### H4
+    """
+    toc = make_toc(plugin, text)
+    assert len(toc) == 1
+    assert len(toc[0].children) == 1


### PR DESCRIPTION
Hi,

I've added tests for lektor-markdown-header-anchors. There are three tests, parametrized to run once on the default configuration, and once on the random anchors configuration.

* `test_unique_anchors`: fails on the default config, succeeds on random anchors. will be fixed in the following pull requests.
* `test_inverse_headers`: succeeds on both configs (fails before @mitsuhiko's second commit)
* `test_two_level_jump fails`: on both, will be fixed in the following pull requests.

Thanks,
Baruch 