### PR TITLE
when adding anchor, generate sign with link for easy referencing

### DIFF
--- a/lektor_markdown_header_anchors.py
+++ b/lektor_markdown_header_anchors.py
@@ -20,7 +20,7 @@ class MarkdownHeaderAnchorsPlugin(Plugin):
                 else:
                     anchor = slugify(raw)
                 renderer.meta['toc'].append((level, anchor, Markup(text)))
-                return '<h%d id="%s">%s</h%d>' % (level, anchor, text, level)
+                return '<h%d id="%s">%s <a href="#%s" class="anchorlink">&#182;</a></h%d>' % (level, anchor, text, anchor, level)
         config.renderer_mixins.append(HeaderAnchorMixin)
 
     def on_markdown_meta_init(self, meta, **extra):


### PR DESCRIPTION
As done in trac and other wikis, please review this idea for a small ¶ sign on the title that is a link to share and use more easily, instead of looking at the page source code.