### PR TITLE
Updates for Lektor 3.4 & mistune 2

### DIFF
--- a/lektor_markdown_header_anchors.py
+++ b/lektor_markdown_header_anchors.py
@@ -2,8 +2,8 @@ import uuid
 from collections import namedtuple
 
 from lektor.pluginsystem import Plugin
-from lektor.utils import slugify
 from markupsafe import Markup
+from slugify import slugify
 
 TocEntry = namedtuple('TocEntry', ['anchor', 'title', 'children'])
 
@@ -18,7 +18,7 @@ class MarkdownHeaderAnchorsPlugin(Plugin):
                 if self.get_config().get('anchor-type') == "random":
                     anchor = uuid.uuid4().hex[:6]
                 else:
-                    anchor = slugify(raw)
+                    anchor = slugify(text)
                 renderer.meta['toc'].append((level, anchor, Markup(text)))
                 return '<h%d id="%s">%s</h%d>' % (level, anchor, text, level)
         config.renderer_mixins.append(HeaderAnchorMixin)

--- a/lektor_markdown_header_anchors.py
+++ b/lektor_markdown_header_anchors.py
@@ -1,9 +1,9 @@
-from lektor.pluginsystem import Plugin
 import uuid
-from lektor.utils import slugify
-from markupsafe import Markup
 from collections import namedtuple
 
+from lektor.pluginsystem import Plugin
+from lektor.utils import slugify
+from markupsafe import Markup
 
 TocEntry = namedtuple('TocEntry', ['anchor', 'title', 'children'])
 

--- a/lektor_markdown_header_anchors.py
+++ b/lektor_markdown_header_anchors.py
@@ -1,6 +1,7 @@
 import uuid
 from collections import namedtuple
 
+import mistune
 from lektor.pluginsystem import Plugin
 from markupsafe import Markup
 from slugify import slugify
@@ -13,15 +14,9 @@ class MarkdownHeaderAnchorsPlugin(Plugin):
     description = u'Lektor plugin that adds anchors and table of contents to markdown headers.'
 
     def on_markdown_config(self, config, **extra):
-        class HeaderAnchorMixin(object):
-            def header(renderer, text, level, raw):
-                if self.get_config().get('anchor-type') == "random":
-                    anchor = uuid.uuid4().hex[:6]
-                else:
-                    anchor = slugify(text)
-                renderer.meta['toc'].append((level, anchor, Markup(text)))
-                return '<h%d id="%s">%s</h%d>' % (level, anchor, text, level)
-        config.renderer_mixins.append(HeaderAnchorMixin)
+        config.renderer_mixins.append(
+            renderer_mixin_factory(slugify=self._slugify)
+        )
 
     def on_markdown_meta_init(self, meta, **extra):
         meta['toc'] = []
@@ -47,3 +42,32 @@ class MarkdownHeaderAnchorsPlugin(Plugin):
             stack[-1].append(TocEntry(anchor, title, []))
 
         meta['toc'] = toc
+
+    def _slugify(self, text):
+        if self.get_config().get('anchor-type') == "random":
+            return uuid.uuid4().hex[:6]
+        # NB: slugify decodes HTML entities in its input before slugifying
+        return slugify(text)
+
+
+def renderer_mixin_factory(slugify=slugify):
+    def render_header(text, level, meta):
+        anchor = slugify(text)
+        meta['toc'].append((level, anchor, Markup(text)))
+        return '<h%d id="%s">%s</h%d>' % (level, anchor, text, level)
+
+    class RendererMixin_mistune0(object):
+        def header(self, text, level, raw):
+            return render_header(text, level, self.meta)
+
+    class RendererMixin_mistune2(object):
+        def heading(self, text, level):
+            meta = self.lektor.meta  # Lektor >= 3.4
+            return render_header(text, level, meta)
+
+    if mistune.__version__.startswith("0."):
+        return RendererMixin_mistune0
+    elif mistune.__version__.startswith("2."):
+        return RendererMixin_mistune2
+    else:
+        raise RuntimeError("unsupported mistune version")

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
     ],
+    install_requires=[
+        'slugify',
+    ],
     entry_points={
         'lektor.plugins': [
             'markdown-header-anchors = lektor_markdown_header_anchors:MarkdownHeaderAnchorsPlugin',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -74,7 +74,7 @@ def test_toc(make_markdown):
     assert toc == [
         ('heading-one', Markup('Heading One'), []),
         ('heading-two', Markup('Heading Two'), [
-            ('heading-2.1', Markup('Heading 2.1'), []),
+            ('heading-2-1', Markup('Heading 2.1'), []),
         ]),
         ('heading-three', Markup('Heading Three'), []),
     ]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,80 @@
+import inspect
+import re
+from pathlib import Path
+
+from lektor.context import Context
+from lektor.metaformat import serialize
+from lektor.project import Project
+from markupsafe import Markup
+import pytest
+
+from lektor_markdown_header_anchors import MarkdownHeaderAnchorsPlugin
+
+
+def write_file(path, contents):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents)
+
+
+@pytest.fixture
+def env(tmp_path):
+    project_dir = tmp_path
+    project_file = project_dir / "test.lektorproject"
+    write_file(project_file, "")
+    write_file(
+        project_dir / "models/page.ini",
+        (
+            "[fields.body]\n"
+            "type = markdown\n"
+        )
+    )
+
+    project = Project.from_file(project_file)
+    return project.make_env()
+
+
+@pytest.fixture
+def pad(env):
+    pad = env.new_pad()
+    with Context(pad=pad):
+        yield pad
+
+
+@pytest.fixture
+def make_markdown(pad):
+    def make_markdown(markdown_src):
+        fields = [("body", markdown_src)]
+        write_file(
+            Path(pad.env.root_path, "content/contents.lr"),
+            "".join(serialize(fields))
+        )
+        return pad.root["body"]
+
+    return make_markdown
+
+
+def test_html(make_markdown):
+    markdown = make_markdown("# This & That\n")
+    assert re.match(
+        r"<h1 id=([\"'])this-that\1>This &amp; That</h1>\s*\Z",
+        markdown.html
+    )
+
+
+def test_toc(make_markdown):
+    markdown = make_markdown(inspect.cleandoc(
+        """
+        ## Heading One
+        ## Heading Two
+        ### Heading 2.1
+        ## Heading Three
+        """
+    ))
+    toc = markdown.meta["toc"]
+    assert toc == [
+        ('heading-one', Markup('Heading One'), []),
+        ('heading-two', Markup('Heading Two'), [
+            ('heading-2.1', Markup('Heading 2.1'), []),
+        ]),
+        ('heading-three', Markup('Heading Three'), []),
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,20 @@
+[tox]
+envlist =
+    py                          # default lektor
+    lektor33
+    lektor34
+    lektor34-mistune0
+    
+[testenv]
+deps =
+    markupsafe
+    pytest
+
+    lektor33: lektor==3.3.*
+    lektor34: lektor==3.4.*,>=3.4.0b1
+    !lektor33,!lektor34: lektor
+
+    mistune0: mistune<1
+
+commands =
+    pytest {posargs:tests -ra}


### PR DESCRIPTION
This PR adds updates to support running under Lektor 3.4.* and mistune 2.*.

In addition, it adds tests of basic functionality, as well as a tox configuration to run the tests under various versions of Lektor and mistune.

Fixes #14.