### PR TITLE
Further fixes to support mistune2 (Lektor 3.4)

### DIFF
--- a/lektor_markdown_header_anchors.py
+++ b/lektor_markdown_header_anchors.py
@@ -5,9 +5,9 @@ from importlib import metadata
 
 import mistune
 from lektor.pluginsystem import Plugin
+from lektor.utils import slugify
 from markupsafe import escape
 from markupsafe import Markup
-from slugify import slugify
 
 TocEntry = namedtuple('TocEntry', ['anchor', 'title', 'children'])
 

--- a/lektor_markdown_header_anchors.py
+++ b/lektor_markdown_header_anchors.py
@@ -1,9 +1,11 @@
 import uuid
 from collections import namedtuple
+from html.parser import HTMLParser
 from importlib import metadata
 
 import mistune
 from lektor.pluginsystem import Plugin
+from markupsafe import escape
 from markupsafe import Markup
 from slugify import slugify
 
@@ -19,8 +21,9 @@ class MarkdownHeaderAnchorsPlugin(Plugin):
         return dist.metadata.get("summary")
 
     def on_markdown_config(self, config, **extra):
+        anchor_type = self.get_config().get('anchor-type')
         config.renderer_mixins.append(
-            renderer_mixin_factory(slugify=self._slugify)
+            renderer_mixin_factory(anchor_type)
         )
 
     def on_markdown_meta_init(self, meta, **extra):
@@ -48,22 +51,27 @@ class MarkdownHeaderAnchorsPlugin(Plugin):
 
         meta['toc'] = toc
 
-    def _slugify(self, text):
-        if self.get_config().get('anchor-type') == "random":
-            return uuid.uuid4().hex[:6]
-        # NB: slugify decodes HTML entities in its input before slugifying
-        return slugify(text)
 
-
-def renderer_mixin_factory(slugify=slugify):
-    def render_header(text, level, meta):
-        anchor = slugify(text)
+def renderer_mixin_factory(anchor_type=None):
+    def render_header(text, level, meta, raw=None):
+        if anchor_type == "random":
+            anchor = uuid.uuid4().hex[:6]
+        else:
+            if raw is None:
+                # Mistune2 does not make the raw un-marked-up text available,
+                # so we have to regenerate it here by stripping HTML tags from
+                # the markup.
+                #
+                # NB: slugify() decodes HTML entities, as does _strip_tags().
+                # We need to encode here again to prevent double-decoding.
+                raw = escape(_strip_tags(text))
+            anchor = slugify(raw)
         meta['toc'].append((level, anchor, Markup(text)))
         return '<h%d id="%s">%s</h%d>' % (level, anchor, text, level)
 
     class RendererMixin_mistune0(object):
         def header(self, text, level, raw):
-            return render_header(text, level, self.meta)
+            return render_header(text, level, self.meta, raw)
 
     class RendererMixin_mistune2(object):
         def heading(self, text, level):
@@ -76,3 +84,31 @@ def renderer_mixin_factory(slugify=slugify):
         return RendererMixin_mistune2
     else:
         raise RuntimeError("unsupported mistune version")
+
+
+def _strip_tags(inline_html: str) -> str:
+    """Strip HTML tags from inline content.
+
+    This is a fairly stupid HTML tag stripper.  All tags are assumed to be inline.
+
+    NB: This should not be used for security/sanitization purposes. (E.g.
+    the bodies of <script> tags are not stripped.)
+    """
+    parser = _StripTagsParser()
+    parser.feed(inline_html)
+    return parser.close()
+
+
+class _StripTagsParser(HTMLParser):
+    _data: list[str]
+
+    def reset(self) -> None:
+        super().reset()
+        self._data = []
+
+    def handle_data(self, data: str) -> None:
+        self._data.append(data)
+
+    def close(self) -> str:
+        super().close()
+        return "".join(self._data)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -83,3 +83,15 @@ def test_toc(make_markdown):
 def test_plugin_description(env):
     plugin = MarkdownHeaderAnchorsPlugin(env, "dummy-id")
     assert plugin.description.startswith("Lektor plugin that adds anchors")
+
+
+@pytest.mark.parametrize("heading, expected_anchor", [
+    ("`keyword`", "keyword"),
+    ("b&amp;", "b"),
+    ("b&_amp;_", "b-amp"),
+    ("&_amp;_", "amp"),
+])
+def test_anchor(make_markdown, heading, expected_anchor):
+    markdown = make_markdown(f"# {heading}\n")
+    (entry,) = markdown.meta['toc']
+    assert entry.anchor == expected_anchor

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -74,7 +74,7 @@ def test_toc(make_markdown):
     assert toc == [
         ('heading-one', Markup('Heading One'), []),
         ('heading-two', Markup('Heading Two'), [
-            ('heading-2-1', Markup('Heading 2.1'), []),
+            ('heading-2.1', Markup('Heading 2.1'), []),
         ]),
         ('heading-three', Markup('Heading Three'), []),
     ]


### PR DESCRIPTION
Mistune 2 does not provide the `raw` argument, containing the plain-text non-marked-up heading text to the `Renderer.heading` method — it only gets passed the already marked-up text that should go inside the heading tag.  

Mistune0 provided both the raw and the marked-up text to the `Renderer.heading` method. This plugin created anchors by passing the raw text through `slugify`.

This creates issues for headings like

```md
## `keyword`
```

In this case, under mistune2, the `Renderer.heading` method only gets the marked-up content,
`text="<code>keyword</code>`".  Passing that straight to `slugify` yields the anchor `"code-keyword-code"`, rather than the expected and desired `"keyword"`.

This PR, when running under mistune2 so that the raw text is not available, attempts to regenerate it by passing the markup content through a simple HTML tag stripper.

----
Finally, this PR reverts 55dab45cc3d100b819e3c4e1b2b619aa74d85cad (part of #15).
In hindsight, the switch I made in that commit from using `lektor.utils.slugify` to using `slugify.slugify` to generate anchors seems to have been a mistake. Changing the slugification algorithm breaks existing links.  It's probably better to stick with a slightly-wacked slugifier than to break current sites.
(E.g. "setup.py" slugifies to "setup-py" under `slugify.slugify`, but to "setup.py" under `lektor.util.slugify`.)

